### PR TITLE
docs: adjust kubectl_path_documents example

### DIFF
--- a/docs/data-sources/kubectl_path_documents.md
+++ b/docs/data-sources/kubectl_path_documents.md
@@ -19,7 +19,7 @@ data "kubectl_path_documents" "docs" {
 }
 
 resource "kubectl_manifest" "test" {
-    for_each  = toset(data.kubectl_path_documents.docs.documents)
+    for_each  = data.kubectl_path_documents.docs.manifests
     yaml_body = each.value
 }
 ```


### PR DESCRIPTION
The provider documentation calls out the `manifests` attribute as being well-suited for `for_each` expressions. The `for_each` example, however, uses the `documents` attribute instead.

This PR updates the `for_each` example to use the `manifests` attribute.